### PR TITLE
Show either window instead of showing both

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -118,6 +118,8 @@ namespace nino {
                 debug ("MiniWindow button pressed.");
                 miniwindow = new MiniWindow (this);
                 miniwindow.show_all ();
+                hide_on_delete ();
+                update_position ();
                 miniwindow.destroy.connect (() => {
                     miniwindow = null;
                     miniwindow_active = false;


### PR DESCRIPTION
It's fine if the current behavior is intentional, but I think MainWindow should be hidden when users click "Mini Window" button, because users should click this button to save desktop spaces where is used to show this app.

### BEFORE

![screen record from 2019-03-02 12 45 48](https://user-images.githubusercontent.com/26003928/53676926-36273b80-3cec-11e9-9be9-f1eb0c45cee8.gif)

### AFTER

![screen record from 2019-03-02 12 45 03](https://user-images.githubusercontent.com/26003928/53676925-358ea500-3cec-11e9-8d2f-5ef27cad10b4.gif)
